### PR TITLE
Adds support for all straightforward sensors/switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,18 @@ or other intellectual property remain the property of their respective owners.
 
 ## Limitations/TODOs
 
-There are many!
+There are several!
 
 * ~~Not currently possible to set a username or password for MQTT!~~
-* Currently only the Filter, Aux 1, Aux 2, and Super Chlorinate controls are exposed
-* Currently only Air/Pool/Spa Temperature, Pool/Spa Chlorinator (%), Salt Level, and Check System sensors are exposed (need to add especially system messages!)
+* ~~Currently only the Filter, Aux 1, Aux 2, and Super Chlorinate controls are exposed~~
+* ~~Currently only Air/Pool/Spa Temperature, Pool/Spa Chlorinator (%), Salt Level, and Check System sensors are exposed~~ 
+* System Messages are not yet supported
 * Serial failures may result in hanging—the process may not exit nor recover, and may have to be killed manually
 * Metric unit configured systems are not yet supported
 * Not yet possible to use a customized Home Assistant MQTT birth message topic or payload
 * Only one pool controller is supported per MQTT broker (please describe your setup in an issue if this affects you 🤨)
 * Others I'm forgetting
 * Others I don't know about
-
-Fixing several of these will require changing the command line interface,
-hence the warnings below.
 
 ### IMPORTANT:
 
@@ -62,30 +60,76 @@ This venv should remain activated when you run the module as described below.
 
 ## Running
 
+See all options by running: `python -m aqualogic_mqtt.client --help`
+
 The module can be minimally started like so:
 
 ```
 python -m aqualogic_mqtt.client \
   -s [serial port path] \
-  -m [MQTT hostname]:[MQTT port] \
-  -p [MQTT Discovery Prefix]
+  -m [MQTT hostname]:[MQTT port]
 ```
 
-E.g. 
+E.g. the below command starts sending data from a USB RS485 serial device to a MQTT broker running on the same machine, and will enable the "Check System" sensor (and nothing else):
 
 ```console
-(venv-pool)$ python -m aqualogic_mqtt.client -s /dev/ttyUSB0 -m localhost:1883 -p homeassistant
+(venv-pool)$ python -m aqualogic_mqtt.client -s /dev/ttyUSB0 -m localhost:1883
 ```
+
 > [!NOTE]
 > While the topic cannot be covered in depth here, be aware that using multiple USB serial devices (including for example a mix of a USB RS485 interface and Z-Wave or Zigbee stick) may result in unpredictable paths for the serial devices--you may need to set up udev rules to make the correct devices show up at the configured path(s).
 
 It is also possible to use the `-t` option (in lieu of `-s`) to connect to a Serial/TCP converter (e.g. a USR-N510) with a host:port, like so
 ```console
-(venv-pool)$ python -m aqualogic_mqtt.client -t 192.168.1.88:8899 -m localhost:1883 -p homeassistant
+(venv-pool)$ python -m aqualogic_mqtt.client -t 192.168.1.88:8899 -m localhost:1883
 ```
 Note, however, that using a network converter such as this has
 been found to be unreliable for device control (reading values
 usually works well enough).
+
+### Enabling Sensors and Switches
+
+Only the "Check System" sensor is enabled by default. Additional sensors and switches that are present on your system and that you want visible/controllable should be specified using the `-e`/`--enable` option. One or more space-separated device "keys" should be provided to this option; for example, this command:
+
+```
+python -m aqualogic_mqtt.client -e l f aux1 t_p -s /dev/ttyUSB0 -m localhost:1883
+```
+...would enable the Lights (`l`), Filter (`f`), Aux 1 (`aux1`) switches and the Pool Temperature (`t_p`) sensor.
+
+The full list of valid keys is shown in the table below and can be printed by using the `--help` option as mentioned above:
+
+| Key | Sensor/Switch
+| --- | -------------
+| t_a | Air Temperature
+| t_p | Pool Temperature
+| t_s | Spa Temperature
+| cl_p | Pool Chlorinator
+| cl_s | Spa Chlorinator
+| salt | Salt Level
+| s_p | Pump Speed
+| p_p | Pump Power
+| l | Lights
+| f | Filter
+| aux1 | Aux 1
+| aux2 | Aux 2
+| aux3 | Aux 3
+| aux4 | Aux 4
+| aux5 | Aux 5
+| aux6 | Aux 6
+| aux7 | Aux 7
+| aux8 | Aux 8
+| aux9 | Aux 9
+| aux10 | Aux 10
+| aux11 | Aux 11
+| aux12 | Aux 12
+| aux13 | Aux 13
+| aux14 | Aux 14
+| spill | Spillover
+| v3 | Valve 3
+| v4 | Valve 4
+| h1 | Heater 1
+| hauto | Heater Auto Mode
+| sc | Super Chlorinate
 
 ### MQTT Connection Options
 
@@ -116,7 +160,7 @@ To avoid specifying the MQTT client password on the command line (where it may b
 ### Home Assistant related options
 
 * `-p DISCOVER_PREFIX` or `--discover-prefix DISCOVER_PREFIX`
-  * The MQTT Discovery Prefix determines the "path" on the MQTT broker where the interface is exposed. For Home Assistant discovery to work, you should use `homeassistant`, which is the default unless you have changed it in your configuration.
+  * The MQTT Discovery Prefix determines the "path" on the MQTT broker where the interface is exposed. The default for this option is `homeassistant`, which matches the default in Home Assistant. If you have changed it in your Home Assistant configuration, you should specify a different value here.
 
 ## Running in a container
 

--- a/aqualogic_mqtt/client.py
+++ b/aqualogic_mqtt/client.py
@@ -31,21 +31,14 @@ class Client:
     _panel = None
     _paho_client = None
     _panel_thread = None
-    _identifier = None
-    _discover_prefix = None
     _formatter = None
     _disconnect_retries = 3
     _disconnect_retry_wait_max = 30
     _disconnect_retry_wait = 1
     _disconnect_retry_num = 0
 
-    def __init__(self, identifier="aqualogic", discover_prefix="homeassistant", 
-                 client_id=None, transport='tcp', protocol_num=5):
-        self._identifier = identifier
-        self._discover_prefix = discover_prefix
-
-        self._formatter = Messages(identifier, discover_prefix)
-
+    def __init__(self, formatter:Messages, client_id=None, transport='tcp', protocol_num=5):
+        self._formatter = formatter
         self._panel = AquaLogic(web_port=0)
 
         protocol = mqtt.MQTTv311 if protocol_num == 3 else mqtt.MQTTv5
@@ -167,12 +160,19 @@ if __name__ == "__main__":
                     prog='aqualogic_mqtt',
                     description='MQTT adapter for pool controllers',
                     )
+    
+    g_group = parser.add_argument_group("General options")
+    g_group.add_argument('-e', '--enable', nargs="+", action="extend",
+        choices=[k for k in Messages.get_valid_entity_meta()], metavar='',
+        help=f"enable one or more entities; valid options are: {', '.join([k+' ('+v+')' for k, v in Messages.get_valid_entity_meta().items()])}")
+
     source_group = parser.add_argument_group("source options")
     source_group_mex = source_group.add_mutually_exclusive_group(required=True)
     source_group_mex.add_argument('-s', '--serial', type=str, metavar="/dev/path",
         help="serial device source (path)")
     source_group_mex.add_argument('-t', '--tcp', type=str, metavar="tcpserialhost:port",
         help="network serial adapter source in the format host:port")
+    
     mqtt_group = parser.add_argument_group('MQTT destination options')
     mqtt_group.add_argument('-m', '--mqtt-dest', required=True, type=str, metavar="mqtthost:port",
         help="MQTT broker destination in the format host:port")
@@ -186,16 +186,20 @@ if __name__ == "__main__":
         help="MQTT protocol major version number (default is 5)")
     mqtt_group.add_argument('--mqtt-transport', type=str, choices=["tcp","websockets"], default="tcp",
         help="MQTT transport mode (default is tcp unless dest port is 9001 or 443)")
+    
     ha_group = parser.add_argument_group("Home Assistant options")
     ha_group.add_argument('-p', '--discover-prefix', default="homeassistant", type=str, 
         help="MQTT prefix path (default is \"homeassistant\")")
-    
+        
     args = parser.parse_args()
     
     source = args.serial if args.serial is not None else args.tcp
     dest = args.mqtt_dest
     
-    mqtt_client = Client(discover_prefix=args.discover_prefix, 
+    formatter = Messages(identifier="aqualogic", discover_prefix=args.discover_prefix, enable=args.enable)
+    print(args.enable)
+    
+    mqtt_client = Client(formatter=formatter, 
                          client_id=args.mqtt_clientid, transport=args.mqtt_transport, 
                          protocol_num=args.mqtt_version
                          )

--- a/aqualogic_mqtt/messages.py
+++ b/aqualogic_mqtt/messages.py
@@ -11,20 +11,112 @@ class Messages:
     _ha_status_path = None
     _onoff = {False: "OFF", True: "ON"}
     
-    def __init__(self, identifier, discover_prefix):
+    def __init__(self, identifier, discover_prefix, enable):
         self._identifier = identifier #TODO: Sanitize?
         self._discover_prefix = discover_prefix #TODO: Sanitize?
         self._root = f"{self._discover_prefix}/device/{self._identifier}"
         self._ha_status_path = f"{self._discover_prefix}/status" #TODO: Make path configurable
 
-        self._values_for_control_state_dict = {
-            States.CHECK_SYSTEM: { "key": "cs", "id": f"{ self._identifier }_binary_sensor_check_system", "name": "Check System" },
-            States.LIGHTS: { "key": "l", "id": f"{ self._identifier }_light_lights", "name": "Lights" },
-            States.FILTER: { "key": "f", "id": f"{ self._identifier }_switch_filter", "name": "Filter" },
-            States.AUX_1: { "key": "aux1", "id": f"{ self._identifier }_switch_aux_1", "name": "Aux 1" },
-            States.AUX_2: { "key": "aux2", "id": f"{ self._identifier }_switch_aux_2", "name": "Aux 2" },
-            States.SUPER_CHLORINATE: { "key": "sc", "id": f"{ self._identifier }_switch_super_chlorinate", "name": "Super Chlorinate" }
+        self._control_dict = { k:v for k,v in Messages.get_control_dict(self._identifier).items() if k in enable }
+        self._sensor_dict = { k:v for k,v in Messages.get_sensor_dict(self._identifier).items() if k in enable }
+    
+    def get_control_dict(identifier = "aqualogic"):
+        return {
+            #"cs": { "state": States.CHECK_SYSTEM, "id": f"{ identifier }_binary_sensor_check_system", "name": "Check System" },
+            "l": { "state": States.LIGHTS, "id": f"{ identifier }_light_lights", "name": "Lights" },
+            "f": { "state": States.FILTER, "id": f"{ identifier }_switch_filter", "name": "Filter" },
+            "aux1": { "state": States.AUX_1, "id": f"{ identifier }_switch_aux_1", "name": "Aux 1" },
+            "aux2": { "state": States.AUX_2, "id": f"{ identifier }_switch_aux_2", "name": "Aux 2" },
+            "aux3": { "state": States.AUX_3, "id": f"{ identifier }_switch_aux_3", "name": "Aux 3" },
+            "aux4": { "state": States.AUX_4, "id": f"{ identifier }_switch_aux_4", "name": "Aux 4" },
+            "aux5": { "state": States.AUX_5, "id": f"{ identifier }_switch_aux_5", "name": "Aux 5" },
+            "aux6": { "state": States.AUX_6, "id": f"{ identifier }_switch_aux_6", "name": "Aux 6" },
+            "aux7": { "state": States.AUX_7, "id": f"{ identifier }_switch_aux_7", "name": "Aux 7" },
+            "aux8": { "state": States.AUX_8, "id": f"{ identifier }_switch_aux_8", "name": "Aux 8" },
+            "aux9": { "state": States.AUX_9, "id": f"{ identifier }_switch_aux_9", "name": "Aux 9" },
+            "aux10": { "state": States.AUX_10, "id": f"{ identifier }_switch_aux_10", "name": "Aux 10" },
+            "aux11": { "state": States.AUX_11, "id": f"{ identifier }_switch_aux_11", "name": "Aux 11" },
+            "aux12": { "state": States.AUX_12, "id": f"{ identifier }_switch_aux_12", "name": "Aux 12" },
+            "aux13": { "state": States.AUX_13, "id": f"{ identifier }_switch_aux_13", "name": "Aux 13" },
+            "aux14": { "state": States.AUX_14, "id": f"{ identifier }_switch_aux_14", "name": "Aux 14" },
+            "spill": { "state": States.SPILLOVER, "id": f"{ identifier }_switch_spillover", "name": "Spillover" },
+            "v3": { "state": States.VALVE_3, "id": f"{ identifier }_switch_valve_3", "name": "Valve 3" },
+            "v4": { "state": States.VALVE_4, "id": f"{ identifier }_switch_valve_4", "name": "Valve 4" },
+            "h1": { "state": States.HEATER_1, "id": f"{ identifier }_switch_heater_1", "name": "Heater 1" },
+            "hauto": { "state": States.HEATER_AUTO_MODE, "id": f"{ identifier }_switch_heater_auto", "name": "Heater Auto Mode" },
+            "sc": { "state": States.SUPER_CHLORINATE, "id": f"{ identifier }_switch_super_chlorinate", "name": "Super Chlorinate" }
         }
+    
+    def get_sensor_dict(identifier = "aqualogic"):
+        return {
+            "t_a": {
+                "id": f"{ identifier }_sensor_air_temperature",
+                "attr": "air_temp",
+                "p": "sensor",
+                "dev_cla":"temperature",
+                "unit_of_meas":"°F",
+                "name": "Air Temperature"
+            },
+            "t_p": {
+                "id": f"{ identifier }_sensor_pool_temperature",
+                "attr": "pool_temp", 
+                "p": "sensor",
+                "dev_cla": "temperature",
+                "unit_of_meas": "°F",
+                "name": "Pool Temperature"
+            },
+            "t_s": {
+                "id": f"{ identifier }_sensor_spa_temperature",
+                "attr": "spa_temp",
+                "p": "sensor",
+                "dev_cla": "temperature",
+                "unit_of_meas": "°F",
+                "name": "Spa Temperature"
+            },
+            "cl_p": {
+                "id": f"{ identifier }_sensor_pool_chlorinator",
+                "attr": "pool_chlorinator",
+                "p": "sensor",
+                "dev_cla": None,
+                "unit_of_meas": "%",
+                "name": "Pool Chlorinator"
+            },
+            "cl_s": {
+                "id": f"{ identifier }_sensor_spa_chlorinator",
+                "attr": "spa_chlorinator",
+                "p": "sensor",
+                "dev_cla": None,
+                "unit_of_meas": "%",
+                "name": "Spa Chlorinator"
+            },
+            "salt": {
+                "id": f"{ identifier }_sensor_salt_level",
+                "attr": "salt_level",
+                "p": "sensor",
+                "dev_cla": None,
+                "unit_of_meas": "ppm",
+                "name": "Salt Level"
+            },
+            "s_p": {
+                "id": f"{ identifier }_sensor_pump_speed",
+                "attr": "pump_speed",
+                "p": "sensor",
+                "dev_cla": None,
+                "unit_of_meas": None,
+                "name": "Pump Speed"
+            },
+            "p_p": {
+                "id": f"{ identifier }_sensor_pump_power",
+                "attr": "pump_power",
+                "p": "sensor",
+                "dev_cla": "power",
+                "unit_of_meas": "W",
+                "name": "Pump Power"
+            }
+        }
+    
+    def get_valid_entity_meta():
+        return { k: v['name'] for k, v in (Messages.get_sensor_dict() | Messages.get_control_dict()).items() }
 
     def get_subscription_topics(self):
         return [f"{self._discover_prefix}/device/{self._identifier}/+/set"]
@@ -35,26 +127,17 @@ class Messages:
     def get_state_topic(self):
         return f"{self._root}/state"
     
-    def _get_id_for_al_state(self, state): #TODO: Make public?
-        return self._values_for_control_state_dict[state]["id"]
-
     def get_state_message(self, panel):
-        return json.dumps({
-            "t_a": panel.air_temp,
-            "t_p": panel.pool_temp,
-            "t_s": panel.spa_temp,
-            "s_p": panel.pump_speed,
-            "p_p": panel.pump_power,
-            "c_p": panel.pool_chlorinator,
-            "c_s": panel.spa_chlorinator,
-            "salt": panel.salt_level,
+        state = {
             "cs": self._onoff[panel.get_state(States.CHECK_SYSTEM)],
-            "l": self._onoff[panel.get_state(States.LIGHTS)],
-            "f": self._onoff[panel.get_state(States.FILTER)],
-            "aux1": self._onoff[panel.get_state(States.AUX_1)],
-            "aux2": self._onoff[panel.get_state(States.AUX_2)],
-            "sc": self._onoff[panel.get_state(States.SUPER_CHLORINATE)],
-        })
+        }
+        for k, v in self._sensor_dict.items():
+            state[k] = getattr(panel, v['attr'])
+
+        for k, v in self._control_dict.items():
+            state[k] = self._onoff[panel.get_state(v['state'])]
+
+        return json.dumps(state)
     
     #TODO: ^ and v move out of this class, to divorce it from Aqualogic panel?
 
@@ -62,10 +145,10 @@ class Messages:
         if topic == self._ha_status_path and msg == "online": #TODO: Make configurable?
             return [(self.get_discovery_topic(), self.get_discovery_message())] 
         
-        state_dict_filtered = { s:d for (s,d) in self._values_for_control_state_dict.items() if f"{self._root}/{d['id']}/set" == topic }
+        state_dict_filtered = { k:v for (k,v) in self._control_dict.items() if f"{self._root}/{v['id']}/set" == topic }
         logging.debug(f"{state_dict_filtered=}")
-        for s in state_dict_filtered: # Really there will be only one...
-            panel.set_state(s, True if msg == "ON" else False)
+        for k,v in state_dict_filtered.items(): # Really there will be only one...
+            panel.set_state(v['state'], True if msg == "ON" else False)
             return []
 
     def get_discovery_message(self):
@@ -85,33 +168,6 @@ class Messages:
                 "url": "https://github.com/SphtKr/aqualogic_mqtt"
             },
             "cmps": {
-                f"{ self._identifier }_sensor_air_temperature": {
-                    "p": "sensor",
-                    "dev_cla":"temperature",
-                    "unit_of_meas":"°F",
-                    "val_tpl":"{{ value_json.t_a }}",
-                    "obj_id": f"{ self._identifier }_sensor_air_temperature",
-                    "uniq_id": f"{ self._identifier }_sensor_air_temperature",
-                    "name": "Air Temperature"
-                },
-                f"{ self._identifier }_sensor_pool_temperature": {
-                    "p": "sensor",
-                    "dev_cla": "temperature",
-                    "unit_of_meas": "°F",
-                    "val_tpl": "{{ value_json.t_p }}",
-                    "obj_id": f"{ self._identifier }_sensor_pool_temperature",
-                    "uniq_id": f"{ self._identifier }_sensor_pool_temperature",
-                    "name": "Pool Temperature"
-                },
-                f"{ self._identifier }_sensor_spa_temperature": {
-                    "p": "sensor",
-                    "dev_cla": "temperature",
-                    "unit_of_meas": "°F",
-                    "val_tpl": "{{ value_json.t_s }}",
-                    "obj_id": f"{ self._identifier }_sensor_spa_temperature",
-                    "uniq_id": f"{ self._identifier }_sensor_spa_temperature",
-                    "name": "Spa Temperature"
-                },
                 f"{ self._identifier }_binary_sensor_check_system": {
                     "p": "binary_sensor",
                     "dev_cla":"problem",
@@ -119,50 +175,37 @@ class Messages:
                     "obj_id": f"{ self._identifier }_binary_sensor_check_system",
                     "uniq_id": f"{ self._identifier }_binary_sensor_check_system",
                     "name": "Check System"
-                },
-                f"{ self._identifier }_sensor_pool_chlorinator": {
-                    "p": "sensor",
-                    "unit_of_meas": "%",
-                    "val_tpl": "{{ value_json.c_p }}",
-                    "obj_id": f"{ self._identifier }_sensor_pool_chlorinator",
-                    "uniq_id": f"{ self._identifier }_sensor_pool_chlorinator",
-                    "name": "Pool Chlorinator"
-                },
-                f"{ self._identifier }_sensor_spa_chlorinator": {
-                    "p": "sensor",
-                    "unit_of_meas": "%",
-                    "val_tpl": "{{ value_json.c_s }}",
-                    "obj_id": f"{ self._identifier }_sensor_spa_chlorinator",
-                    "uniq_id": f"{ self._identifier }_sensor_spa_chlorinator",
-                    "name": "Spa Chlorinator"
-                },
-                f"{ self._identifier }_sensor_salt_level": {
-                    "p": "sensor",
-                    "unit_of_meas": "ppm",
-                    "val_tpl": "{{ value_json.salt }}",
-                    "obj_id": f"{ self._identifier }_sensor_salt_level",
-                    "uniq_id": f"{ self._identifier }_sensor_salt_level",
-                    "name": "Salt Level"
                 }
             },
             "stat_t": self.get_state_topic(),
             "qos": 2
         }
-        for s in [States.FILTER, States.LIGHTS, States.AUX_1, States.AUX_2, States.SUPER_CHLORINATE]:
-            #TODO: fix waste
+        for k,v in self._sensor_dict.items():
+            cmp = {
+                "p": v["p"],
+                "dev_cla": v["dev_cla"],
+                "unit_of_meas": v["unit_of_meas"],
+                "val_tpl":"{{ value_json." + k + "}}",
+                "obj_id": v["id"],
+                "uniq_id": v["id"],
+                "name": v["name"]
+            }
+            p['cmps'][v["id"]] = cmp
+
+        for k,v in self._control_dict.items():
             cmp = {
                 "p": "switch",
                 "dev_cla": "switch",
-                "val_tpl":"{{ value_json." + self._values_for_control_state_dict[s]["key"] + " }}",
-                "uniq_id": self._get_id_for_al_state(s),
-                "obj_id": self._get_id_for_al_state(s),
-                "name": self._values_for_control_state_dict[s]["name"], #TODO: Make method?
-                "cmd_t": f"{self._root}/{self._get_id_for_al_state(s)}/set"
+                "val_tpl":"{{ value_json." + k + " }}",
+                "uniq_id": v["id"],
+                "obj_id": v["id"],
+                "name": v["name"],
+                "cmd_t": f"{self._root}/{v['id']}/set"
             }
-            if s == States.LIGHTS:
+            if k == "l":
                 cmp['p'] = "light"
                 cmp['stat_val_tpl'] = cmp['val_tpl']
                 del cmp['val_tpl']
                 del cmp['dev_cla']
-            p['cmps'][self._get_id_for_al_state(s)] = cmp
+            p['cmps'][v["id"]] = cmp
         return json.dumps(p)


### PR DESCRIPTION
Enable by passing `-e`/`--enable` and one or more keys. Keys include:

| Key | Sensor/Switch
| --- | -------------
| t_a | Air Temperature
| t_p | Pool Temperature
| t_s | Spa Temperature
| cl_p | Pool Chlorinator
| cl_s | Spa Chlorinator
| salt | Salt Level
| s_p | Pump Speed
| p_p | Pump Power
| l | Lights
| f | Filter
| aux1 | Aux 1
| aux2 | Aux 2
| aux3 | Aux 3
| aux4 | Aux 4
| aux5 | Aux 5
| aux6 | Aux 6
| aux7 | Aux 7
| aux8 | Aux 8
| aux9 | Aux 9
| aux10 | Aux 10
| aux11 | Aux 11
| aux12 | Aux 12
| aux13 | Aux 13
| aux14 | Aux 14
| spill | Spillover
| v3 | Valve 3
| v4 | Valve 4
| h1 | Heater 1
| hauto | Heater Auto Mode
| sc | Super Chlorinate
